### PR TITLE
Bugfix: Handle whitespace and broken links

### DIFF
--- a/convert.rb
+++ b/convert.rb
@@ -84,7 +84,11 @@ class Converter
         target_note_id = link_target.sub('id:', '')
         target_note = @notes[target_note_id]
 
-        "[[#{target_note.title}]]"
+        if target_note.nil?
+          "[Note not found: #{link_text}](#{link_target})"
+        else
+          "[[#{target_note.title}]]"
+        end
       else
         "[#{link_text}](#{link_target})"
       end

--- a/convert.rb
+++ b/convert.rb
@@ -35,7 +35,7 @@ class Note
   private
 
   def input_file_to_md
-    PandocRuby.new([input_file], from: 'org', wrap: 'none').to_gfm
+    PandocRuby.new([(Regexp.escape input_file)], from: 'org', wrap: 'none').to_gfm
   end
 
   def sanitize(row)


### PR DESCRIPTION
I've included two fixes here that I needed to get this script to work for me.

## Whitespace

Now escape whitespace in the `input_file` value. I've seen suggestions online that this may be platform-dependent, but I encountered an issue where pandoc could not handle whitespace in a filename (see line 7):

```fish
[I] ~/orgroam_to_obsidian ❯❯❯ ./convert.rb                                                     main ✱ ◼
Loading: Spanish
Loading: Open-source
Loading: Midpoint Method
Loading: UX Design
/home/chuckles/.local/share/gem/ruby/3.0.0/gems/pandoc-ruby-2.1.7/lib/pandoc-ruby.rb:306:in `execute': pandoc: input/roam/articles/ATS3870: openBinaryFile: does not exist (No such file or directory) (RuntimeError)
	from /home/chuckles/.local/share/gem/ruby/3.0.0/gems/pandoc-ruby-2.1.7/lib/pandoc-ruby.rb:275:in `execute_pandoc'
	from /home/chuckles/.local/share/gem/ruby/3.0.0/gems/pandoc-ruby-2.1.7/lib/pandoc-ruby.rb:269:in `convert_string'
	from /home/chuckles/.local/share/gem/ruby/3.0.0/gems/pandoc-ruby-2.1.7/lib/pandoc-ruby.rb:205:in `convert'
	from /home/chuckles/.local/share/gem/ruby/3.0.0/gems/pandoc-ruby-2.1.7/lib/pandoc-ruby.rb:241:in `block (2 levels) in <class:PandocRuby>'
	from ./convert.rb:38:in `input_file_to_md'
	from ./convert.rb:16:in `initialize'
	from ./convert.rb:60:in `new'
	from ./convert.rb:60:in `block in initialize'
	from ./convert.rb:59:in `each'
	from ./convert.rb:59:in `initialize'
	from ./convert.rb:95:in `new'
	from ./convert.rb:95:in `<main>'
```

Filename in question: `ATS3870 Assessment Essay.org`

I'm not sure how whitespace ended up in my roam files, since they don't seem to follow the snake-case naming convention, but nonethelesss, I think it makes the script more reslilient. Perhaps I've got some links to those custom org files in my roam files?

## Check for bad links

Check for failure to resolve a link using the database. I had this happen to me, seems like a link got broken for me at some point, I figure there should be a graceful alternate behaviour.

```fish
Converting: 2021-09-29
./convert.rb:87:in `block in convert_links': undefined method `title' for nil:NilClass (NoMethodError)
	from ./convert.rb:79:in `gsub'
	from ./convert.rb:79:in `convert_links'
	from ./convert.rb:74:in `convert_and_write_note'
	from ./convert.rb:68:in `block in convert'
	from ./convert.rb:68:in `each_key'
	from ./convert.rb:68:in `convert'
	from ./convert.rb:95:in `<main>'
```

And the note in question once converted:

![image](https://github.com/goshatch/orgroam_to_obsidian/assets/54133784/3329e829-ec9c-4948-a201-86a43fafbc7b)

```markdown
I started learning [Note not found: Spanish](id:c8689012-48ad-4486-bd27-1cea49545d64)....
```
