### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM pandoc/alpine:latest
 
 RUN apk update
 RUN apk add ruby ruby-etc
-RUN gem install bundler
+RUN gem install bundler -v 2.3.18
 
 RUN mkdir -p /opt/orgroam-to-obsidian
 WORKDIR /opt/orgroam-to-obsidian


### PR DESCRIPTION
It seems like `gem install bundler` tries and fails to install `bundler` for Ruby 3.  This specifies the right `bundler` version.