### PR TITLE
feat: Some improvements

### DIFF
--- a/convert.rb
+++ b/convert.rb
@@ -47,7 +47,7 @@ class Note
   private
 
   def input_file_to_md
-    PandocRuby.new([(Shellwords.escape input_file)], from: 'org', wrap: 'none').to_gfm
+    PandocRuby.new([(Shellwords.escape input_file)], :standalone, from: 'org', wrap: 'none').to_gfm
   end
 
   def sanitize(row)

--- a/convert.rb
+++ b/convert.rb
@@ -25,11 +25,15 @@ class Note
   end
 
   def title
+    @row.title.gsub(%r{[\x00\/\\:\*\?\"<>\|]}, '-')
+  end
+
+  def input_title
     @row.title
   end
 
   def filename
-    "#{title}.md".gsub(%r{[\x00\/\\:\*\?\"<>\|]}, '-')
+    "#{title}.md"
   end
 
   def content
@@ -65,11 +69,11 @@ class Converter
       note = Note.new(result)
       if File.extname(note.input_file) != '.org'
         # Skipping encrypted notes
-        puts "Skipping (unsupported file extension): #{note.title}"
+        puts "Skipping (unsupported file extension): #{note.input_title}"
         next
       end
 
-      puts "Loading: #{note.title}"
+      puts "Loading: #{note.input_title}"
       @notes[note.id] = note
     end
     puts '✅ Done loading.'
@@ -81,7 +85,7 @@ class Converter
   end
 
   def convert_and_write_note(note)
-    puts "Converting: #{note.title}"
+    puts "Converting: #{note.input_title}"
     content = convert_links(note)
     File.write("output/#{note.filename}", content)
   end

--- a/convert.rb
+++ b/convert.rb
@@ -20,8 +20,12 @@ class Note
     @row.id
   end
 
+  def roam_file
+    @roam_file ||= "#{@row.file.partition('roam/').last}"
+  end
+
   def input_file
-    @input_file ||= "input/roam/#{@row.file.partition('roam/').last}"
+    @input_file ||= "input/roam/#{roam_file}"
   end
 
   def title
@@ -32,8 +36,8 @@ class Note
     @row.title
   end
 
-  def filename
-    "#{title}.md"
+  def output_file
+    Pathname(@roam_file).dirname + "#{title}.md"
   end
 
   def content
@@ -87,7 +91,10 @@ class Converter
   def convert_and_write_note(note)
     puts "Converting: #{note.input_title}"
     content = convert_links(note)
-    File.write("output/#{note.filename}", content)
+
+    out_path = Pathname("output/#{note.output_file}")
+    out_path.dirname.mkpath
+    out_path.write(content)
   end
 
   def convert_links(note)

--- a/convert.rb
+++ b/convert.rb
@@ -14,7 +14,6 @@ class Note
   def initialize(row)
     r = sanitize(row)
     @row = OpenStruct.new(r)
-    @content = input_file_to_md
   end
 
   def id
@@ -31,6 +30,10 @@ class Note
 
   def filename
     "#{title}.md".gsub(%r{[\x00\/\\:\*\?\"<>\|]}, '-')
+  end
+
+  def content
+    input_file_to_md
   end
 
   private
@@ -60,6 +63,12 @@ class Converter
     results = db.execute('SELECT * FROM nodes ORDER BY id DESC')
     results.each do |result|
       note = Note.new(result)
+      if File.extname(note.input_file) != '.org'
+        # Skipping encrypted notes
+        puts "Skipping (unsupported file extension): #{note.title}"
+        next
+      end
+
       puts "Loading: #{note.title}"
       @notes[note.id] = note
     end


### PR DESCRIPTION
## Description

- fix: Don't fail on encrypted files - just skip them because `pandoc`
  can't process them. Decrypting them in Obsidian is also seems incorrect

- fix: Mismatch between sanitized filename and title in links when
  original `title` contains invalid characters

- feat: Preserve directory structure - closes #9

- feat: Support Org-Roam file-level `:PROPERTIES:`