### PR TITLE
Use roam_root to build input_file

### DIFF
--- a/convert.rb
+++ b/convert.rb
@@ -27,7 +27,7 @@ class Note
   end
 
   def input_file
-    @input_file ||= "input/roam/#{roam_file}"
+    @input_file ||= File.join(@roam_root, roam_file)
   end
 
   def title


### PR DESCRIPTION
Fixes #13, which was already mostly fixed, but missed a line from https://github.com/goshatch/orgroam_to_obsidian/issues/13#issuecomment-2769937006.